### PR TITLE
Dockerize E-commerce Flask App with Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.8-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 80
+CMD ["gunicorn", "--bind", "0.0.0.0:80", "main:app"]

--- a/READMe.md
+++ b/READMe.md
@@ -23,6 +23,7 @@ Efficient: Slim Python base image minimizes overhead.
 
 HOW TO USE 
 
-docker pull monish247/ecommerce_python_image:latest
+docker pull monish247/ecommerce_python_image:latest   
+
 docker run -itd -p 8034:80 monish247/ecommerce_python_image:latest
 

--- a/READMe.md
+++ b/READMe.md
@@ -1,4 +1,4 @@
-## 🐱‍🏍✨Flask Ecommerce✨🐱‍🏍
+## 🐱‍🏍✨Flask E-commerce Application with Gunicorn✨🐱‍🏍
 
 🐍Python Project🐍
 
@@ -9,3 +9,20 @@
 📌Payment Gateway Functionality
 📌Admins can regulate shop products e.g stock level
 📌Admins can change order status
+
+
+OVERVIEW
+
+This Docker image packages a Flask-based e-commerce application, optimized for production use with Gunicorn. The lightweight python:3.8-slim base image ensures efficient and quick deployment.
+
+FEATURES
+
+Flask Framework: Robust and scalable web application built with Flask.
+Gunicorn Server: High-performance WSGI server for running Python web applications.
+Efficient: Slim Python base image minimizes overhead.
+
+HOW TO USE 
+
+docker pull monish247/ecommerce_python_image:latest
+docker run -itd -p 8034:80 monish247/ecommerce_python_image:latest
+


### PR DESCRIPTION
-  Added a Dockerfile to containerize the Flask e-commerce application.
-  Utilized the lightweight python:3.8-slim base image.
-  Configured Gunicorn as the WSGI server for production deployment.
-  Updated the README with instructions for building and running the Docker container.